### PR TITLE
Rename Trello objects to have consistent names

### DIFF
--- a/lib/src/cli/commands/card_module.dart
+++ b/lib/src/cli/commands/card_module.dart
@@ -44,7 +44,7 @@ class GetCardCommand extends CardCommand {
 
   @override
   FutureOr<void> run() async {
-    Card? card = await client.card(cardId).get();
+    TrelloCard? card = await client.card(cardId).get();
     if (card != null) print(tabulateObject(card, fields));
   }
 }
@@ -62,7 +62,7 @@ class ListAttachmentsCommand extends CardCommand {
 
   @override
   FutureOr<void> run() async {
-    List<Attachment> attachments =
+    List<TrelloAttachment> attachments =
         await client.card(cardId).getAttachments(fields: fields);
     print(tabulateObjects(attachments, fields));
   }
@@ -82,7 +82,7 @@ class GetAttachmentCommand extends CardCommand {
 
   @override
   FutureOr<void> run() async {
-    Attachment attachment =
+    TrelloAttachment attachment =
         await client.card(cardId).attachment(attachmentId).get(fields: fields);
     print(tabulateObject(attachment, fields));
   }

--- a/lib/src/cli/commands/list_module.dart
+++ b/lib/src/cli/commands/list_module.dart
@@ -40,7 +40,7 @@ class ListCardsCommand extends ListCommand {
 
   @override
   FutureOr<void> run() async {
-    List<Card> cards = await client.list(listId).getCards(fields: fields);
+    List<TrelloCard> cards = await client.list(listId).getCards(fields: fields);
     print(tabulateObjects(cards, fields));
   }
 }

--- a/lib/src/cli/commands/member_module.dart
+++ b/lib/src/cli/commands/member_module.dart
@@ -48,7 +48,7 @@ class GetMemberCommand extends MemberCommand {
 
   @override
   FutureOr<void> run() async {
-    Member member = await client.member(memberId).get();
+    TrelloMember member = await client.member(memberId).get();
     print(tabulateObject(member, fields));
   }
 }
@@ -68,7 +68,7 @@ class ListMemberBoardsCommand extends MemberCommand {
 
   @override
   FutureOr<void> run() async {
-    List<Board> boards =
+    List<TrelloBoard> boards =
         await client.member(memberId).getBoards(fields: fields);
     print(tabulateObjects(boards, fields));
   }

--- a/lib/src/sdk/boards/board_models.dart
+++ b/lib/src/sdk/boards/board_models.dart
@@ -1,8 +1,8 @@
 import '../client.dart';
 import '../trello_object_model.dart';
 
-class Board extends TrelloObject<BoardFields> {
-  Board(source, List<BoardFields> fields)
+class TrelloBoard extends TrelloObject<BoardFields> {
+  TrelloBoard(source, List<BoardFields> fields)
       : super(source, fields, all: fields.contains(BoardFields.all));
 
   BoardId get id => BoardId(getValue(BoardFields.id));

--- a/lib/src/sdk/cards/attachment_client.dart
+++ b/lib/src/sdk/cards/attachment_client.dart
@@ -18,10 +18,13 @@ class AttachmentClient {
   /// Get a specific Attachment on a Card.
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-idattachment-get
-  Future<Attachment> get({List<AttachmentFields>? fields}) async => _client
-      .get<Map<String, dynamic>>('/1/cards/$_cardId/attachments/$_attachmentId')
-      .then((response) => response.data)
-      .then((data) => Attachment(data, fields ?? [AttachmentFields.all]));
+  Future<TrelloAttachment> get({List<AttachmentFields>? fields}) async =>
+      _client
+          .get<Map<String, dynamic>>(
+              '/1/cards/$_cardId/attachments/$_attachmentId')
+          .then((response) => response.data)
+          .then((data) =>
+              TrelloAttachment(data, fields ?? [AttachmentFields.all]));
 
   /// Download an Attachment on a Card
   ///

--- a/lib/src/sdk/cards/card_client.dart
+++ b/lib/src/sdk/cards/card_client.dart
@@ -25,7 +25,7 @@ class CardClient {
   /// Get a card by its ID
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-get
-  Future<Card?> get({List<CardFields>? fields}) async => _client
+  Future<TrelloCard?> get({List<CardFields>? fields}) async => _client
       .get<dynamic>(
         '/1/cards/$_cardId',
         queryParameters: {
@@ -33,7 +33,7 @@ class CardClient {
         },
       )
       .then((response) => response.data)
-      .then((data) => Card(data, fields ?? [CardFields.all]));
+      .then((data) => TrelloCard(data, fields ?? [CardFields.all]));
 
   /// Get Attachments on a Card
   ///
@@ -42,7 +42,7 @@ class CardClient {
   /// List the attachments on a card
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-get
-  Future<List<Attachment>> getAttachments({
+  Future<List<TrelloAttachment>> getAttachments({
     AttachmentFilter filter = AttachmentFilter.falsE,
     List<AttachmentFields>? fields,
   }) async =>
@@ -59,6 +59,7 @@ class CardClient {
               })
           .then((response) => response.data ?? [])
           .then((data) => data
-              .map((item) => Attachment(item, fields ?? [AttachmentFields.all]))
+              .map((item) =>
+                  TrelloAttachment(item, fields ?? [AttachmentFields.all]))
               .toList());
 }

--- a/lib/src/sdk/cards/card_models.dart
+++ b/lib/src/sdk/cards/card_models.dart
@@ -3,8 +3,8 @@ import 'dart:ffi';
 import '../client.dart';
 import '../trello_object_model.dart';
 
-class Card extends TrelloObject<CardFields> {
-  Card(source, List<CardFields> fields)
+class TrelloCard extends TrelloObject<CardFields> {
+  TrelloCard(source, List<CardFields> fields)
       : super(source, fields, all: fields.contains(CardFields.all));
 
   CardId get id => CardId(getValue(CardFields.id));
@@ -129,8 +129,9 @@ enum CardFilter {
   open,
 }
 
-class Attachment extends TrelloObject<AttachmentFields> {
-  Attachment(source, List<AttachmentFields> fields) : super(source, fields);
+class TrelloAttachment extends TrelloObject<AttachmentFields> {
+  TrelloAttachment(source, List<AttachmentFields> fields)
+      : super(source, fields);
 
   String get url => getValue(AttachmentFields.url);
 

--- a/lib/src/sdk/lists/list_client.dart
+++ b/lib/src/sdk/lists/list_client.dart
@@ -15,13 +15,13 @@ class ListClient {
   /// List the cards in a list
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-lists/#api-lists-id-cards-get
-  Future<List<Card>> getCards({List<CardFields>? fields}) async =>
+  Future<List<TrelloCard>> getCards({List<CardFields>? fields}) async =>
       ((await _client.get<List<dynamic>>(
                 '/1/lists/${_id}/cards',
                 queryParameters: {},
               ))
                   .data ??
               [])
-          .map((item) => Card(item, fields ?? [CardFields.all]))
+          .map((item) => TrelloCard(item, fields ?? [CardFields.all]))
           .toList(growable: false);
 }

--- a/lib/src/sdk/members/member_client.dart
+++ b/lib/src/sdk/members/member_client.dart
@@ -14,7 +14,7 @@ class MemberClient {
   /// GET /1/members/{id}
   ///
   /// Get a member
-  Future<Member> get({
+  Future<TrelloMember> get({
     MemberActions? actions,
     MemberBoards? boards,
     MemberBoardBackgrounds boardBackgrounds = MemberBoardBackgrounds.none,
@@ -66,7 +66,7 @@ class MemberClient {
     return (_client
         .get<dynamic>('/1/members/${_id}', queryParameters: queryParameters)
         .then((response) => response.data)
-        .then((item) => Member(item, fields ?? [MemberFields.all])));
+        .then((item) => TrelloMember(item, fields ?? [MemberFields.all])));
   }
 
   /// Get Boards that Member belongs to
@@ -76,7 +76,7 @@ class MemberClient {
   /// Lists the boards that the user is a member of.
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-members/#api-members-id-boards-get
-  Future<List<Board>> getBoards({
+  Future<List<TrelloBoard>> getBoards({
     MemberBoardFilter filter = MemberBoardFilter.all,
     List<BoardFields>? fields,
   }) async =>
@@ -89,7 +89,7 @@ class MemberClient {
               ))
                   .data ??
               [])
-          .map((item) => Board(item, fields ?? [BoardFields.all]))
+          .map((item) => TrelloBoard(item, fields ?? [BoardFields.all]))
           .toList(growable: false);
 }
 

--- a/lib/src/sdk/members/member_models.dart
+++ b/lib/src/sdk/members/member_models.dart
@@ -2,8 +2,8 @@ import '../client.dart';
 import '../trello_models.dart';
 import '../trello_object_model.dart';
 
-class Member extends TrelloObject<MemberFields> {
-  Member(source, List<MemberFields> fields) : super(source, fields);
+class TrelloMember extends TrelloObject<MemberFields> {
+  TrelloMember(source, List<MemberFields> fields) : super(source, fields);
 
   MemberId get id => MemberId(getValue(MemberFields.id));
   String get fullName => getValue(MemberFields.fullName);


### PR DESCRIPTION
Currently `TrelloList` is an outlier due to not wanting to clash with the`List` class.

- TMember
- TBoard
- TList
- TCard
- TAttachment