### PR TITLE
Steal TaskEither from fpdart

### DIFF
--- a/bin/trello.dart
+++ b/bin/trello.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:dio/dio.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:trello_sdk/src/sdk/http_client.dart';
 import 'package:trello_sdk/trello_cli.dart';
 

--- a/bin/trello.dart
+++ b/bin/trello.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:trello_sdk/src/sdk/http_client.dart';
 import 'package:trello_sdk/trello_cli.dart';
 

--- a/lib/src/cli/commands/board/board_lists_list_command.dart
+++ b/lib/src/cli/commands/board/board_lists_list_command.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
-
 import '../../../../trello_sdk.dart';
 import 'board_module.dart';
 
@@ -19,11 +17,13 @@ class ListListsCommand extends BoardCommand {
 
   @override
   FutureOr<void> run() async =>
-      (await boardId.map(boardClient).map(getLists).unwrapFuture())
-          .map((lists) => tabulateObjects(lists, fields))
+      (await TaskEither.fromEither(boardId.map(boardClient))
+              .flatMap(getLists)
+              .map((lists) => tabulateObjects(lists, fields))
+              .run())
           .collapse(printOutput);
 
-  Future<Either<Failure, List<TrelloList>>> getLists(BoardClient boardClient) =>
+  TaskEither<Failure, List<TrelloList>> getLists(BoardClient boardClient) =>
       boardClient.getLists(fields: fields);
 
   BoardClient boardClient(BoardId boardId) => client.board(boardId);

--- a/lib/src/cli/commands/board/board_module.dart
+++ b/lib/src/cli/commands/board/board_module.dart
@@ -1,5 +1,5 @@
 import 'package:args/command_runner.dart';
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../../trello_sdk.dart';
 import '../commands.dart';

--- a/lib/src/cli/commands/board/board_module.dart
+++ b/lib/src/cli/commands/board/board_module.dart
@@ -1,5 +1,4 @@
 import 'package:args/command_runner.dart';
-import 'package:fpdart/fpdart.dart';
 
 import '../../../../trello_sdk.dart';
 import '../commands.dart';

--- a/lib/src/cli/commands/card/card_attachment_download_command.dart
+++ b/lib/src/cli/commands/card/card_attachment_download_command.dart
@@ -9,11 +9,10 @@ class DownloadAttachmentCommand extends CardCommand {
       : super('download-attachment', 'Download an Attachment file', client);
 
   @override
-  FutureOr<void> run() async => (await TaskEither.flatten(
-              TaskEither.fromEither(_download(cardId, attachmentId, fileName)))
-          .run())
-      .map((_) => "Download complete")
-      .collapse(printOutput);
+  FutureOr<void> run() async =>
+      (await taskEitherFlatE(_download(cardId, attachmentId, fileName)).run())
+          .map((_) => "Download complete")
+          .collapse(printOutput);
 
   Function3<Either<Failure, CardId>, Either<Failure, AttachmentId>,
           Either<Failure, FileName>, Either<Failure, TaskEither<Failure, void>>>

--- a/lib/src/cli/commands/card/card_attachment_get_command.dart
+++ b/lib/src/cli/commands/card/card_attachment_get_command.dart
@@ -16,11 +16,10 @@ class GetAttachmentCommand extends CardCommand {
   ];
 
   @override
-  FutureOr<void> run() async => (await TaskEither.flatten(
-              TaskEither.fromEither(_getAttachment(cardId, attachmentId)))
-          .run())
-      .map((attachment) => tabulateObject(attachment, fields))
-      .collapse(printOutput);
+  FutureOr<void> run() async =>
+      (await taskEitherFlatE(_getAttachment(cardId, attachmentId)).run())
+          .map((attachment) => tabulateObject(attachment, fields))
+          .collapse(printOutput);
 
   Function2<Either<Failure, CardId>, Either<Failure, AttachmentId>,
           Either<Failure, TaskEither<Failure, TrelloAttachment>>>

--- a/lib/src/cli/commands/card/card_attachments_list_command.dart
+++ b/lib/src/cli/commands/card/card_attachments_list_command.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
-
 import '../../../../trello_sdk.dart';
 import 'card_module.dart';
 
@@ -18,10 +16,10 @@ class ListAttachmentsCommand extends CardCommand {
 
   @override
   FutureOr<void> run() async =>
-      (await cardId.map(_getAttachments).unwrapFuture())
+      (await TaskEither.fromEither(cardId).flatMap(_getAttachments).run())
           .map((attachments) => tabulateObjects(attachments, fields))
           .collapse(printOutput);
 
-  Future<Either<Failure, List<TrelloAttachment>>> _getAttachments(cardId) =>
+  TaskEither<Failure, List<TrelloAttachment>> _getAttachments(cardId) =>
       client.card(cardId).attachments(fields: fields);
 }

--- a/lib/src/cli/commands/card/card_get_command.dart
+++ b/lib/src/cli/commands/card/card_get_command.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
-
 import '../../../../trello_sdk.dart';
 import 'card_module.dart';
 
@@ -17,10 +15,10 @@ class GetCardCommand extends CardCommand {
   ];
 
   @override
-  FutureOr<void> run() async => (await cardId.map(doGetCard).unwrapFuture())
-      .map((card) => tabulateObject(card, fields))
-      .collapse(printOutput);
+  FutureOr<void> run() async =>
+      (await TaskEither.fromEither(cardId).flatMap(_getCard).run())
+          .map((card) => tabulateObject(card, fields))
+          .collapse(printOutput);
 
-  Future<Either<Failure, TrelloCard>> doGetCard(cardId) =>
-      client.card(cardId).get();
+  TaskEither<Failure, TrelloCard> _getCard(cardId) => client.card(cardId).get();
 }

--- a/lib/src/cli/commands/card/card_member_add_command.dart
+++ b/lib/src/cli/commands/card/card_member_add_command.dart
@@ -11,11 +11,11 @@ class AddMemberToCardCommand extends CardCommand {
       nextParameter('Member Id').map((id) => MemberId(id));
 
   @override
-  FutureOr<void> run() => TaskEither.flatten(
-          TaskEither.fromEither(map2either(cardId, memberId, _addMember)))
-      .map((_) => "Added member")
-      .run()
-      .then((value) => value.collapse(printOutput));
+  FutureOr<void> run() =>
+      taskEitherFlatE(map2either(cardId, memberId, _addMember))
+          .map((_) => "Added member")
+          .run()
+          .then((value) => value.collapse(printOutput));
 
   TaskEither<Failure, void> _addMember(CardId cardId, MemberId memberId) =>
       client

--- a/lib/src/cli/commands/card/card_module.dart
+++ b/lib/src/cli/commands/card/card_module.dart
@@ -1,5 +1,5 @@
 import 'package:args/command_runner.dart';
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../../trello_sdk.dart';
 import '../commands.dart';

--- a/lib/src/cli/commands/card/card_module.dart
+++ b/lib/src/cli/commands/card/card_module.dart
@@ -1,5 +1,4 @@
 import 'package:args/command_runner.dart';
-import 'package:fpdart/fpdart.dart';
 
 import '../../../../trello_sdk.dart';
 import '../commands.dart';

--- a/lib/src/cli/commands/commands.dart
+++ b/lib/src/cli/commands/commands.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:tabular/tabular.dart';
 
 import '../../../trello_sdk.dart';

--- a/lib/src/cli/commands/commands.dart
+++ b/lib/src/cli/commands/commands.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:tabular/tabular.dart';
 
 import '../../../trello_sdk.dart';

--- a/lib/src/cli/commands/list/list_cards_list_command.dart
+++ b/lib/src/cli/commands/list/list_cards_list_command.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
-
 import '../../../../trello_sdk.dart';
 import 'list_module.dart';
 
@@ -17,13 +15,14 @@ class ListCardsCommand extends ListCommand {
   ];
 
   @override
-  FutureOr<void> run() async =>
-      (await listId.map(listClient).map(getCards).unwrapFuture())
+  FutureOr<void> run() async => (await TaskEither.flatten(
+              TaskEither.fromEither(listId.map(_listClient).map(_getCardsTE)))
           .map((cards) => tabulateObjects(cards, fields))
-          .collapse(printOutput);
+          .run())
+      .collapse(printOutput);
 
-  Future<Either<Failure, List<TrelloCard>>> getCards(ListClient listClient) =>
+  TaskEither<Failure, List<TrelloCard>> _getCardsTE(ListClient listClient) =>
       listClient.getCards(fields: fields);
 
-  ListClient listClient(ListId listId) => client.list(listId);
+  ListClient _listClient(ListId listId) => client.list(listId);
 }

--- a/lib/src/cli/commands/list/list_cards_list_command.dart
+++ b/lib/src/cli/commands/list/list_cards_list_command.dart
@@ -15,11 +15,11 @@ class ListCardsCommand extends ListCommand {
   ];
 
   @override
-  FutureOr<void> run() async => (await TaskEither.flatten(
-              TaskEither.fromEither(listId.map(_listClient).map(_getCardsTE)))
-          .map((cards) => tabulateObjects(cards, fields))
-          .run())
-      .collapse(printOutput);
+  FutureOr<void> run() async =>
+      (await taskEitherFlatE(listId.map(_listClient).map(_getCardsTE))
+              .map((cards) => tabulateObjects(cards, fields))
+              .run())
+          .collapse(printOutput);
 
   TaskEither<Failure, List<TrelloCard>> _getCardsTE(ListClient listClient) =>
       listClient.getCards(fields: fields);

--- a/lib/src/cli/commands/list/list_module.dart
+++ b/lib/src/cli/commands/list/list_module.dart
@@ -1,5 +1,4 @@
 import 'package:args/command_runner.dart';
-import 'package:dartz/dartz.dart';
 
 import '../../../../trello_sdk.dart';
 import '../commands.dart';

--- a/lib/src/cli/commands/member/member_get_command.dart
+++ b/lib/src/cli/commands/member/member_get_command.dart
@@ -20,9 +20,7 @@ class GetMemberCommand extends MemberCommand {
   ];
 
   @override
-  FutureOr<void> run() async {
-    (await client.member(memberId).get())
-        .map((member) => tabulateObject(member, fields))
-        .collapse(printOutput);
-  }
+  FutureOr<void> run() async => (await client.member(memberId).get().run())
+      .map((member) => tabulateObject(member, fields))
+      .collapse(printOutput);
 }

--- a/lib/src/cli/commands/member/member_list_command.dart
+++ b/lib/src/cli/commands/member/member_list_command.dart
@@ -18,7 +18,7 @@ class ListMemberBoardsCommand extends MemberCommand {
 
   @override
   FutureOr<void> run() async =>
-      (await client.member(memberId).getBoards(fields: fields))
+      (await client.member(memberId).getBoards(fields: fields).run())
           .map((boards) => tabulateObjects(boards, fields))
           .collapse(printOutput);
 }

--- a/lib/src/sdk/boards/board_client.dart
+++ b/lib/src/sdk/boards/board_client.dart
@@ -1,5 +1,3 @@
-import 'package:fpdart/fpdart.dart';
-
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
 

--- a/lib/src/sdk/boards/board_client.dart
+++ b/lib/src/sdk/boards/board_client.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
@@ -16,22 +16,23 @@ class BoardClient {
   /// Get the Lists on a Board
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-lists-get
-  Future<Either<Failure, List<TrelloList>>> getLists({
+  TaskEither<Failure, List<TrelloList>> getLists({
     CardFilter cards = CardFilter.all,
     List<CardFields> card_fields = const [CardFields.all],
     ListFilter filter = ListFilter.all,
     List<ListFields> fields = const [ListFields.all],
-  }) async =>
-      (await _client.get<List<dynamic>>(
-        '/1/boards/${_id}/lists',
-        queryParameters: {
-          'cards': cards.name,
-          'card_fields': asCsv(card_fields),
-          'filter': filter.name,
-          'fields': asCsv(fields),
-        },
-      ))
-          .leftMap((failure) => failure.withContext({'boardId': _id.value}))
+  }) =>
+      _client
+          .get<List<dynamic>>(
+            '/1/boards/${_id}/lists',
+            queryParameters: {
+              'cards': cards.name,
+              'card_fields': asCsv(card_fields),
+              'filter': filter.name,
+              'fields': asCsv(fields),
+            },
+          )
+          .mapLeft((failure) => failure.withContext({'boardId': _id.value}))
           .map((response) => response.data ?? [])
           .map((items) => items
               .map((item) => TrelloList(item, fields))

--- a/lib/src/sdk/cards/attachment_client.dart
+++ b/lib/src/sdk/cards/attachment_client.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:progress_bar/progress_bar.dart';
 
 import '../../../trello_sdk.dart';
@@ -19,10 +19,10 @@ class AttachmentClient {
   /// Get a specific Attachment on a Card.
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-idattachment-get
-  Future<Either<Failure, TrelloAttachment>> get(
-          {List<AttachmentFields>? fields}) async =>
-      (await _client.get<Map<String, dynamic>>(
-              '/1/cards/$_cardId/attachments/$_attachmentId'))
+  TaskEither<Failure, TrelloAttachment> get({List<AttachmentFields>? fields}) =>
+      _client
+          .get<Map<String, dynamic>>(
+              '/1/cards/$_cardId/attachments/$_attachmentId')
           .map((response) => response.data)
           .map((data) =>
               TrelloAttachment(data, fields ?? [AttachmentFields.all]));
@@ -32,10 +32,9 @@ class AttachmentClient {
   /// GET (url from 'Get an Attachment on a Card')
   ///
   /// Download an attachment and save it to disk.
-  Future<Either<Failure, void>> download(FileName fileName) async =>
-      (await get(fields: [AttachmentFields.url, AttachmentFields.bytes])).fold(
-        (failure) => Left(failure),
-        (attachment) async => await _client.download(
+  TaskEither<Failure, void> download(FileName fileName) =>
+      get(fields: [AttachmentFields.url, AttachmentFields.bytes]).flatMap(
+        (attachment) => _client.download(
           attachment.url,
           fileName,
           headers: {

--- a/lib/src/sdk/cards/attachment_client.dart
+++ b/lib/src/sdk/cards/attachment_client.dart
@@ -1,4 +1,3 @@
-import 'package:fpdart/fpdart.dart';
 import 'package:progress_bar/progress_bar.dart';
 
 import '../../../trello_sdk.dart';

--- a/lib/src/sdk/cards/card_client.dart
+++ b/lib/src/sdk/cards/card_client.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
@@ -22,17 +22,17 @@ class CardClient {
   /// Get a card by its ID
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-get
-  Future<Either<Failure, TrelloCard>> get({List<CardFields>? fields}) async =>
-      (await _client.get<dynamic>(
+  TaskEither<Failure, TrelloCard> get({List<CardFields>? fields}) => _client
+      .get<dynamic>(
         '/1/cards/$_cardId',
         queryParameters: {
           'fields': asCsv(fields ?? [CardFields.all]),
         },
-      ))
-          .map((response) => response.data)
-          .filter((data) => data != null,
-              () => ResourceNotFoundFailure(resource: 'Card ID: $_cardId'))
-          .map((data) => TrelloCard(data, fields ?? [CardFields.all]));
+      )
+      .map((response) => response.data)
+      .filterOrElse((data) => data != null,
+          (data) => ResourceNotFoundFailure(resource: 'Card ID: $_cardId'))
+      .map((data) => TrelloCard(data, fields ?? [CardFields.all]));
 
   /// Get Attachments on a Card
   ///
@@ -41,20 +41,21 @@ class CardClient {
   /// List the attachments on a card
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-get
-  Future<Either<Failure, List<TrelloAttachment>>> attachments({
+  TaskEither<Failure, List<TrelloAttachment>> attachments({
     AttachmentFilter filter = AttachmentFilter.falsE,
     List<AttachmentFields>? fields,
-  }) async =>
-      (await _client.get<List<dynamic>>('/1/cards/$_cardId/attachments',
+  }) =>
+      _client
+          .get<List<dynamic>>('/1/cards/$_cardId/attachments',
               queryParameters: {
-            'filter': filter.name.toLowerCase(),
-            'fields': asCsv(fields ?? [AttachmentFields.all]),
-          },
+                'filter': filter.name.toLowerCase(),
+                'fields': asCsv(fields ?? [AttachmentFields.all]),
+              },
               headers: {
-            'Authorization':
-                'OAuth oauth_consumer_key="${_authentication.key}", '
-                    'oauth_token="${_authentication.token}"',
-          }))
+                'Authorization':
+                    'OAuth oauth_consumer_key="${_authentication.key}", '
+                        'oauth_token="${_authentication.token}"',
+              })
           .map((response) => response.data ?? [])
           .map((items) => items
               .map((item) =>
@@ -68,10 +69,10 @@ class CardClient {
   /// Update a card
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-put
-  Future<Either<Failure, TrelloCard>> put(TrelloCard card) async =>
-      (await _client.put('/1/cards/$_cardId', data: card))
-          .map((response) => response.data)
-          .map((data) => TrelloCard(data, [CardFields.all]));
+  TaskEither<Failure, TrelloCard> put(TrelloCard card) => _client
+      .put('/1/cards/$_cardId', data: card)
+      .map((response) => response.data)
+      .map((data) => TrelloCard(data, [CardFields.all]));
 
   /// Add a Member to a Card
   ///
@@ -80,7 +81,7 @@ class CardClient {
   /// Add a member to a card
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-idmembers-post
-  Future<Either<Failure, void>> addMember(MemberId memberId) =>
+  TaskEither<Failure, void> addMember(MemberId memberId) =>
       _client.post('/1/cards/$_cardId/idMembers', queryParameters: {
         'value': memberId.value,
       });

--- a/lib/src/sdk/cards/card_client.dart
+++ b/lib/src/sdk/cards/card_client.dart
@@ -30,8 +30,10 @@ class CardClient {
         },
       )
       .map((response) => response.data)
-      .filterOrElse((data) => data != null,
-          (data) => ResourceNotFoundFailure(resource: 'Card ID: $_cardId'))
+      .filterOrElse(
+        (data) => data != null,
+        (data) => ResourceNotFoundFailure(resource: 'Card ID: $_cardId'),
+      )
       .map((data) => TrelloCard(data, fields ?? [CardFields.all]));
 
   /// Get Attachments on a Card

--- a/lib/src/sdk/cards/card_client.dart
+++ b/lib/src/sdk/cards/card_client.dart
@@ -1,5 +1,3 @@
-import 'package:fpdart/fpdart.dart';
-
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
 

--- a/lib/src/sdk/client.dart
+++ b/lib/src/sdk/client.dart
@@ -1,5 +1,4 @@
-import 'package:dartz/dartz.dart';
-
+import '../../trello_sdk.dart';
 import 'boards/boards.dart';
 import 'cards/cards.dart';
 import 'http_client.dart';

--- a/lib/src/sdk/extensions/either_extensions.dart
+++ b/lib/src/sdk/extensions/either_extensions.dart
@@ -1,10 +1,5 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 extension CollapsableEither<L, R> on Either<L, R> {
   T collapse<T>(T Function(Either<L, R>) fn) => fn(this);
-}
-
-extension UnrwappableFutureInEither<L, R> on Either<L, Future<Either<L, R>>> {
-  Future<Either<L, R>> unwrapFuture() async =>
-      (await Either.sequenceFuture(this)).flatMap(id);
 }

--- a/lib/src/sdk/extensions/either_extensions.dart
+++ b/lib/src/sdk/extensions/either_extensions.dart
@@ -1,4 +1,4 @@
-import 'package:fpdart/fpdart.dart';
+import '../fp/fp.dart';
 
 extension CollapsableEither<L, R> on Either<L, R> {
   T collapse<T>(T Function(Either<L, R>) fn) => fn(this);

--- a/lib/src/sdk/fp/fp.dart
+++ b/lib/src/sdk/fp/fp.dart
@@ -1,0 +1,4 @@
+export 'package:fpdart/fpdart.dart';
+
+export 'fp_either.dart';
+export 'fp_types.dart';

--- a/lib/src/sdk/fp/fp.dart
+++ b/lib/src/sdk/fp/fp.dart
@@ -1,4 +1,5 @@
-export 'package:fpdart/fpdart.dart';
+export 'package:dartz/dartz.dart';
 
 export 'fp_either.dart';
+export 'fp_task_either.dart';
 export 'fp_types.dart';

--- a/lib/src/sdk/fp/fp_either.dart
+++ b/lib/src/sdk/fp/fp_either.dart
@@ -1,0 +1,36 @@
+import 'fp.dart';
+
+// lift
+Function1<Either<L, A>, Either<L, B>> lift1either<L, A, B>(B Function(A a) f) =>
+    (Either<L, A> fa) => map1either(fa, f);
+
+Function2<Either<L, A>, Either<L, B>, Either<L, C>> lift2either<L, A, B, C>(
+        C Function(A a, B b) f) =>
+    (Either<L, A> fa, Either<L, B> fb) => map2either(fa, fb, f);
+
+Function3<Either<L, A>, Either<L, B>, Either<L, C>, Either<L, D>>
+    lift3either<L, A, B, C, D>(D Function(A a, B b, C c) f) =>
+        (Either<L, A> fa, Either<L, B> fb, Either<L, C> fc) =>
+            map3either(fa, fb, fc, f);
+
+// map
+Either<L, B> map1either<L, A, A2 extends A, B>(
+        Either<L, A2> fa, B Function(A a) fun) =>
+    fa.fold(left, (a) => right(fun(a)));
+
+Either<L, C> map2either<L, A, A2 extends A, B, B2 extends B, C>(
+        Either<L, A2> fa, Either<L, B2> fb, C Function(A a, B b) fun) =>
+    fa.fold(
+        left,
+        (a) => fb.fold(
+            left,
+            (b) => right(fun(
+                  a,
+                  b,
+                ))));
+
+Either<L, D> map3either<L, A, A2 extends A, B, B2 extends B, C, C2 extends C,
+            D>(Either<L, A2> fa, Either<L, B2> fb, Either<L, C2> fc,
+        D Function(A a, B b, C c) fun) =>
+    fa.fold(left,
+        (a) => fb.fold(left, (b) => fc.fold(left, (c) => right(fun(a, b, c)))));

--- a/lib/src/sdk/fp/fp_either.dart
+++ b/lib/src/sdk/fp/fp_either.dart
@@ -34,3 +34,6 @@ Either<L, D> map3either<L, A, A2 extends A, B, B2 extends B, C, C2 extends C,
         D Function(A a, B b, C c) fun) =>
     fa.fold(left,
         (a) => fb.fold(left, (b) => fc.fold(left, (c) => right(fun(a, b, c)))));
+
+TaskEither<L, R> taskEitherFlatE<L, R>(Either<L, TaskEither<L, R>> input) =>
+    TaskEither.flatten(TaskEither.fromEither(input));

--- a/lib/src/sdk/fp/fp_task_either.dart
+++ b/lib/src/sdk/fp/fp_task_either.dart
@@ -1,0 +1,87 @@
+import '../fp/fp.dart';
+
+class TaskEither<L, R> {
+  /// Build a [TaskEither] from a function returning a `Future<Either<L, R>>`.
+  const TaskEither(this._run);
+  final Future<Either<L, R>> Function() _run;
+
+  /// Run the task and return a `Future<Either<L, R>>`.
+  Future<Either<L, R>> run() => _run();
+
+  /// Pattern matching to convert a [TaskEither] to a [Task].
+  ///
+  /// Execute `onLeft` when running this [TaskEither] returns a [Left].
+  /// Otherwise execute `onRight`.
+  Task<A> match<A>(A Function(L l) onLeft, A Function(R r) onRight) =>
+      Task(() async => (await run()).fold(onLeft, onRight));
+
+  /// Apply the function contained inside `a` to change the value on the [Right] from
+  /// type `R` to a value of type `C`.
+  @override
+  TaskEither<L, C> ap<C>(covariant TaskEither<L, C Function(R r)> a) =>
+      a.flatMap((f) => flatMap((v) => pure(f(v))));
+
+  /// Returns a [TaskEither] that returns a `Right(a)`.
+  @override
+  TaskEither<L, C> pure<C>(C a) => TaskEither(() async => Right(a));
+
+  /// Used to chain multiple functions that return a [TaskEither].
+  ///
+  /// You can extract the value of every [Right] in the chain without
+  /// handling all possible missing cases.
+  /// If running any of the tasks in the chain returns [Left], the result is [Left].
+  @override
+  TaskEither<L, C> flatMap<C>(covariant TaskEither<L, C> Function(R r) f) =>
+      TaskEither(() => run().then(
+            (either) async => either.fold(
+              left,
+              (r) => f(r).run(),
+            ),
+          ));
+
+  /// If running this [TaskEither] returns [Right], then change its value from type `R` to
+  /// type `C` using function `f`.
+  @override
+  TaskEither<L, C> map<C>(C Function(R r) f) => ap(pure(f));
+
+  /// Flat a [TaskEither] contained inside another [TaskEither] to be a single [TaskEither].
+  factory TaskEither.flatten(TaskEither<L, TaskEither<L, R>> taskEither) =>
+      taskEither.flatMap(identity);
+
+  /// Build a [TaskEither] that returns `either`.
+  factory TaskEither.fromEither(Either<L, R> either) =>
+      TaskEither(() async => either);
+
+  /// Build a [TaskEither] that returns a `Left(left)`.
+  factory TaskEither.left(L left) => TaskEither(() async => Left(left));
+
+  /// If `f` applied on this [TaskEither] as [Right] returns `true`, then return this [TaskEither].
+  /// If it returns `false`, return the result of `onFalse` in a [Left].
+  TaskEither<L, R> filterOrElse(
+          bool Function(R r) f, L Function(R r) onFalse) =>
+      flatMap((r) => f(r) ? TaskEither.of(r) : TaskEither.left(onFalse(r)));
+
+  /// Build a [TaskEither] that returns a `Right(r)`.
+  ///
+  /// Same of `TaskEither.right`.
+  factory TaskEither.of(R r) => TaskEither(() async => Right(r));
+
+  /// Change the value in the [Left] of [TaskEither].
+  TaskEither<C, R> mapLeft<C>(C Function(L l) f) => TaskEither(
+      () async => (await run()).fold((l) => Left(f(l)), (r) => Right(r)));
+
+  /// Build a [TaskEither] from the result of running `task`.
+  ///
+  /// Same of `TaskEither.rightTask`
+  factory TaskEither.fromTask(Task<R> task) =>
+      TaskEither(() async => Right(await task.run()));
+
+  /// Define two functions to change both the [Left] and [Right] value of the
+  /// [TaskEither].
+  ///
+  /// Same as `map`+`mapLeft` but for both [Left] and [Right]
+  /// (`map` is only to change [Right], while `mapLeft` is only to change [Left]).
+  TaskEither<C, D> bimap<C, D>(
+          C Function(L l) mapLeft, D Function(R r) mapRight) =>
+      map(mapRight).mapLeft(mapLeft);
+}

--- a/lib/src/sdk/fp/fp_types.dart
+++ b/lib/src/sdk/fp/fp_types.dart
@@ -1,10 +1,17 @@
-typedef Function1<A, B> = B Function(A a);
-typedef Function2<A, B, C> = C Function(A a, B b);
-typedef Function3<A, B, C, D> = D Function(A a, B b, C c);
-
-class Tuple3<A, B, C> {
-  Tuple3(this.a, this.b, this.c);
-  final A a;
-  final B b;
-  final C c;
-}
+/// Returns the given `a`.
+///
+/// Same as `id`.
+///
+/// Shortcut function to return the input parameter:
+/// ```dart
+/// final either = Either<String, int>.of(10);
+///
+/// /// Without using `identity`, you must write a function to return
+/// /// the input parameter `(l) => l`.
+/// final noId = either.match((l) => l, (r) => '$r');
+///
+/// /// Using `identity`/`id`, the function just returns its input parameter.
+/// final withIdentity = either.match(identity, (r) => '$r');
+/// final withId = either.match(id, (r) => '$r');
+/// ```
+T identity<T>(T a) => a;

--- a/lib/src/sdk/fp/fp_types.dart
+++ b/lib/src/sdk/fp/fp_types.dart
@@ -1,0 +1,10 @@
+typedef Function1<A, B> = B Function(A a);
+typedef Function2<A, B, C> = C Function(A a, B b);
+typedef Function3<A, B, C, D> = D Function(A a, B b, C c);
+
+class Tuple3<A, B, C> {
+  Tuple3(this.a, this.b, this.c);
+  final A a;
+  final B b;
+  final C c;
+}

--- a/lib/src/sdk/http_client.dart
+++ b/lib/src/sdk/http_client.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:fpdart/fpdart.dart';
 
 import '../../trello_sdk.dart';
 

--- a/lib/src/sdk/lists/list_client.dart
+++ b/lib/src/sdk/lists/list_client.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
@@ -16,12 +16,12 @@ class ListClient {
   /// List the cards in a list
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-lists/#api-lists-id-cards-get
-  Future<Either<Failure, List<TrelloCard>>> getCards(
-          {List<CardFields>? fields}) async =>
-      (await _client.get<List<dynamic>>(
-        '/1/lists/${_id}/cards',
-        queryParameters: {},
-      ))
+  TaskEither<Failure, List<TrelloCard>> getCards({List<CardFields>? fields}) =>
+      _client
+          .get<List<dynamic>>(
+            '/1/lists/${_id}/cards',
+            queryParameters: {},
+          )
           .map((response) => response.data ?? [])
           .map((items) => items
               .map((item) => TrelloCard(item, fields ?? [CardFields.all]))

--- a/lib/src/sdk/lists/list_client.dart
+++ b/lib/src/sdk/lists/list_client.dart
@@ -1,5 +1,3 @@
-import 'package:fpdart/fpdart.dart';
-
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
 

--- a/lib/src/sdk/members/member_client.dart
+++ b/lib/src/sdk/members/member_client.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:fpdart/fpdart.dart';
 
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
@@ -14,7 +14,7 @@ class MemberClient {
   /// GET /1/members/{id}
   ///
   /// Get a member
-  Future<Either<Failure, TrelloMember>> get({
+  TaskEither<Failure, TrelloMember> get({
     MemberActions? actions,
     MemberBoards? boards,
     MemberBoardBackgrounds boardBackgrounds = MemberBoardBackgrounds.none,
@@ -37,7 +37,7 @@ class MemberClient {
     bool paidAccount = false,
     bool savedSearches = false,
     MemberTokens tokens = MemberTokens.none,
-  }) async {
+  }) {
     Map<String, String> queryParameters = {
       'boardBackgrounds': boardBackgrounds.name,
       'boardStars': boardStars.toString(),
@@ -63,8 +63,8 @@ class MemberClient {
     if (actions != null) queryParameters['actions'] = actions;
     if (boards != null) queryParameters['boards'] = boards;
     if (notifications != null) queryParameters['notifications'] = notifications;
-    return (await _client.get<dynamic>('/1/members/${_id}',
-            queryParameters: queryParameters))
+    return _client
+        .get<dynamic>('/1/members/${_id}', queryParameters: queryParameters)
         .map((r) => r.data)
         .map((item) => TrelloMember(item, fields ?? [MemberFields.all]));
   }
@@ -76,17 +76,18 @@ class MemberClient {
   /// Lists the boards that the user is a member of.
   ///
   /// https://developer.atlassian.com/cloud/trello/rest/api-group-members/#api-members-id-boards-get
-  Future<Either<Failure, List<TrelloBoard>>> getBoards({
+  TaskEither<Failure, List<TrelloBoard>> getBoards({
     MemberBoardFilter filter = MemberBoardFilter.all,
     List<BoardFields>? fields,
-  }) async =>
-      (await _client.get<List<dynamic>>(
-        '/1/members/${this._id}/boards',
-        queryParameters: {
-          'filter': filter.name,
-          'fields': asCsv(fields ?? [BoardFields.all])
-        },
-      ))
+  }) =>
+      _client
+          .get<List<dynamic>>(
+            '/1/members/${this._id}/boards',
+            queryParameters: {
+              'filter': filter.name,
+              'fields': asCsv(fields ?? [BoardFields.all])
+            },
+          )
           .map((response) => response.data ?? [])
           .map((items) => items
               .map((item) => TrelloBoard(item, fields ?? [BoardFields.all]))

--- a/lib/src/sdk/members/member_client.dart
+++ b/lib/src/sdk/members/member_client.dart
@@ -1,5 +1,3 @@
-import 'package:fpdart/fpdart.dart';
-
 import '../../../trello_sdk.dart';
 import '../http_client.dart';
 

--- a/lib/src/sdk/sdk.dart
+++ b/lib/src/sdk/sdk.dart
@@ -1,3 +1,4 @@
+export 'fp/fp.dart';
 export 'boards/boards.dart';
 export 'cards/cards.dart';
 export 'client.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  dartz:
+    dependency: "direct main"
+    description:
+      name: dartz
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.1"
   dio:
     dependency: "direct main"
     description:
@@ -85,13 +92,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
-  fpdart:
-    dependency: "direct main"
-    description:
-      name: fpdart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.14"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,13 +71,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  dartz:
-    dependency: "direct main"
-    description:
-      name: dartz
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.10.1"
   dio:
     dependency: "direct main"
     description:
@@ -92,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
+  fpdart:
+    dependency: "direct main"
+    description:
+      name: fpdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.14"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   meta: ^1.7.0
   tabular: ^0.6.3+1
   progress_bar: ^1.0.0
-  dartz: ^0.10.1
+  fpdart: ^0.0.14
 
 dev_dependencies:
   lints: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   meta: ^1.7.0
   tabular: ^0.6.3+1
   progress_bar: ^1.0.0
-  fpdart: ^0.0.14
+  dartz: ^0.10.1
 
 dev_dependencies:
   lints: ^1.0.1

--- a/test/src/cli/commands/board/board_list_lists_command_test.dart
+++ b/test/src/cli/commands/board/board_list_lists_command_test.dart
@@ -29,8 +29,9 @@ void main() {
     //when
     await commandRunner.run(['board', 'list-lists', boardId]);
     //then
+    Tuple2(1, 2);
     expect(testClient.fetchHistory.length, 1);
-    var requestOptions = testClient.fetchHistory[0].head;
+    var requestOptions = testClient.fetchHistory[0].a;
     expect(requestOptions.method, 'GET');
     expect(requestOptions.baseUrl, 'example.com');
     expect(requestOptions.path, '/1/boards/$boardId/lists');

--- a/test/src/cli/commands/board/board_list_lists_command_test.dart
+++ b/test/src/cli/commands/board/board_list_lists_command_test.dart
@@ -31,7 +31,7 @@ void main() {
     //then
     Tuple2(1, 2);
     expect(testClient.fetchHistory.length, 1);
-    var requestOptions = testClient.fetchHistory[0].a;
+    var requestOptions = testClient.fetchHistory[0].head;
     expect(requestOptions.method, 'GET');
     expect(requestOptions.baseUrl, 'example.com');
     expect(requestOptions.path, '/1/boards/$boardId/lists');

--- a/test/src/mocks/dio_mock.dart
+++ b/test/src/mocks/dio_mock.dart
@@ -1,8 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:trello_sdk/src/sdk/client.dart';
+import 'package:trello_sdk/src/sdk/fp/fp_types.dart';
 import 'package:trello_sdk/src/sdk/http_client.dart';
 
 class DioAdapterMock implements HttpClientAdapter {

--- a/test/src/mocks/dio_mock.dart
+++ b/test/src/mocks/dio_mock.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:trello_sdk/src/sdk/client.dart';
-import 'package:trello_sdk/src/sdk/fp/fp_types.dart';
+import 'package:trello_sdk/src/sdk/fp/fp.dart';
 import 'package:trello_sdk/src/sdk/http_client.dart';
 
 class DioAdapterMock implements HttpClientAdapter {


### PR DESCRIPTION
After a brief conversion to using `fpdart` and then finding that it doesn't have the all documentation it promises, steal parts of the `TaskEither` and switch back to `dartz` which is a more complete library, even if it lacks docs.